### PR TITLE
fix: issue when candidates count more then answers in voice

### DIFF
--- a/schulze/__init__.py
+++ b/schulze/__init__.py
@@ -2,6 +2,7 @@
 
 For more information read http://en.wikipedia.org/wiki/Schulze_method.
 """
+import itertools
 
 __author__ = "Michael G. Parker"
 __contact__ = "http://omgitsmgp.com/"
@@ -17,16 +18,31 @@ def _add_remaining_ranks(d, candidate, remaining_ranks, weight):
 
 def _add_ranks_to_d(d, ranks, weight):
     for i, rank in enumerate(ranks):
-        remaining_ranks = ranks[i + 1:]
+        remaining_ranks = ranks[i + 1 :]
         for candidate in rank:
             _add_remaining_ranks(d, candidate, remaining_ranks, weight)
 
 
-def _compute_d(weighted_ranks):
+def _fill_missed_candidates(weighted_ranks, candidates):
+    weighted_ranks = list(weighted_ranks)
+    for index, rank in enumerate(weighted_ranks):
+        flatten_ranks = list(itertools.chain(*rank[0]))
+        if len(flatten_ranks) == len(candidates):
+            continue
+        rest_candidates = [c for c in candidates if c not in flatten_ranks]
+        if rest_candidates:
+            weighted_ranks[index] = list(rank)
+            weighted_ranks[index][0] = list(rank[0])
+            weighted_ranks[index][0].append(rest_candidates)
+    return weighted_ranks
+
+
+def _compute_d(weighted_ranks, candidates):
     """Computes the d array in the Schulze method.
 
     d[V,W] is the number of voters who prefer candidate V over W.
     """
+    weighted_ranks = _fill_missed_candidates(weighted_ranks, candidates)
     d = defaultdict(int)
     for ranks, weight in weighted_ranks:
         _add_ranks_to_d(d, ranks, weight)
@@ -54,7 +70,8 @@ def _compute_p(d, candidates):
                         curr_value = p.get((candidate_2, candidate_3), 0)
                         new_value = min(
                             p.get((candidate_2, candidate_1), 0),
-                            p.get((candidate_1, candidate_3), 0))
+                            p.get((candidate_1, candidate_3), 0),
+                        )
                         if new_value > curr_value:
                             p[candidate_2, candidate_3] = new_value
 
@@ -91,10 +108,12 @@ def compute_ranks(candidates, weighted_ranks):
     Parameter candidates is a sequence containing all the candidates.
 
     Parameter weighted_ranks is a sequence of (ranks, weight) pairs.
-    The first element, ranks, is a ranking of the candidates. It is an array of arrays so that we
+    The first element, ranks, is a ranking of the candidates.
+    It is an array of arrays so that we
     can express ties. For example, [[a, b], [c], [d, e]] represents a = b > c > d = e.
-    The second element, weight, is typically the number of voters that chose this ranking.
+    The second element, weight, is typically the number of voters that chose
+    this ranking.
     """
-    d = _compute_d(weighted_ranks)
+    d = _compute_d(weighted_ranks, candidates)
     p = _compute_p(d, candidates)
     return _rank_p(candidates, p)


### PR DESCRIPTION
Realized Schulze method feature: when a voter doesn't rank all candidates, then this is interpreted as if this voter strictly prefers all ranked to all unranked candidates, and is indifferent among all unranked candidates.
